### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mudassarhayee/1a6dd166-3c27-4bbc-9bce-dd851ae0976d/7f3f32e9-7306-4f96-8d2b-b8489eba5a53/_apis/work/boardbadge/b9ca97b9-3742-4537-9351-cf73e4b052e6)](https://dev.azure.com/mudassarhayee/1a6dd166-3c27-4bbc-9bce-dd851ae0976d/_boards/board/t/7f3f32e9-7306-4f96-8d2b-b8489eba5a53/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#2. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.